### PR TITLE
Fix: unsupported RELA relocation error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,13 @@ obj-m += $(MODULE_NAME).o
 KERNEL_HEAD := $(shell uname -r)
 KERNELDIR := /lib/modules/$(KERNEL_HEAD)/build
 PWD := $(shell pwd)
+ARCH := $(shell uname -m)
+ifeq ($(ARCH),aarch64)
+KCPPFLAGS="-mcmodel=large"
+endif
+
 all:
-	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+	KCPPFLAGS=$(KCPPFLAGS) $(MAKE) -C $(KERNELDIR) M=$(PWD) modules
 
 clean:
 	rm -rf *.ko *.mod *.mod.c *.o modules.* Module.symvers


### PR DESCRIPTION
Signed-off-by: Fanjun Kong <fanjun.kong@uisee.com>


After finish building on arm64, there will be some error when loading ko:
module trace_noschedule: unsupported RELA relocation: 275
I found workaround here:
https://xixitalk.github.io/blog/2018/05/03/linux-module-unsupported-RELA-relocation/

This patch works well on my board, feel free to help review, or give me more comments.

Thanks
FJ